### PR TITLE
Fix error crash when pressing play to close game

### DIFF
--- a/Engine/Module/ModuleTime.cpp
+++ b/Engine/Module/ModuleTime.cpp
@@ -116,7 +116,6 @@ void ModuleTime::Play()
 	{
 		game_time_clock->Stop();
 		App->editor->OpenScene(TMP_SCENE_PATH);
-		remove(TMP_SCENE_PATH);
 	}
 }
 


### PR DESCRIPTION
Fixing a bug where engine crashed if play was pressed to load previous scene to gameplay.