### PR TITLE
Feature/ui image aspect ratio

### DIFF
--- a/Engine/Component/ComponentImage.cpp
+++ b/Engine/Component/ComponentImage.cpp
@@ -60,12 +60,29 @@ void ComponentImage::Render(float4x4* projection)
 
 	if (texture_to_render != nullptr)
 	{
-		float4x4* model = &owner->transform_2d.GetSizedGlobalModelMatrix();
+		ScaleOp aspect_ratio_scaling;
+
+		if (preserve_aspect_ratio)
+		{
+			if (owner->transform_2d.size.x / texture_aspect_ratio > owner->transform_2d.size.y)
+			{
+				aspect_ratio_scaling = float4x4::Scale(float3(owner->transform_2d.size.y * texture_aspect_ratio, owner->transform_2d.size.y, 1.f));
+			}
+			else
+			{
+				aspect_ratio_scaling = float4x4::Scale(float3(owner->transform_2d.size.x, owner->transform_2d.size.x / texture_aspect_ratio, 1.f));
+			}
+		}
+		else
+		{
+			aspect_ratio_scaling = float4x4::Scale(float3(owner->transform_2d.size, 1.f));
+		}
+		float4x4 model = owner->transform_2d.GetGlobalModelMatrix()  * aspect_ratio_scaling;
 
 		glUseProgram(program);
 		glUniformMatrix4fv(glGetUniformLocation(program, "projection"), 1, GL_TRUE, projection->ptr());
 		glUniform1i(glGetUniformLocation(program, "image"), 0);
-		glUniformMatrix4fv(glGetUniformLocation(program, "model"), 1, GL_TRUE, model->ptr());
+		glUniformMatrix4fv(glGetUniformLocation(program, "model"), 1, GL_TRUE, model.ptr());
 		glUniform4fv(glGetUniformLocation(program, "spriteColor"), 1, color.ptr());
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture_to_render->opengl_texture);
@@ -110,12 +127,14 @@ void ComponentImage::SpecializedSave(Config& config) const
 {
 	config.AddColor(color, "ImageColor");
 	config.AddUInt(texture_uuid, "TextureUUID");
+	config.AddBool(preserve_aspect_ratio, "PreserveAspectRatio");
 }
 
 void ComponentImage::SpecializedLoad(const Config& config)
 {
 	config.GetColor("ImageColor", color, float4::one);
 	texture_uuid = config.GetUInt("TextureUUID", 0);
+	preserve_aspect_ratio = config.GetBool("PreserveAspectRatio", false);
 	if (texture_uuid != 0)
 	{
 		SetTextureToRender(texture_uuid);
@@ -126,6 +145,7 @@ void ComponentImage::SetTextureToRender(uint32_t texture_uuid)
 {
 	this->texture_uuid = texture_uuid;
 	texture_to_render = App->resources->Load<Texture>(texture_uuid);
+	texture_aspect_ratio = (float)texture_to_render->width / texture_to_render->height;
 }
 
 void ComponentImage::SetColor(float4 color)

--- a/Engine/Component/ComponentImage.cpp
+++ b/Engine/Component/ComponentImage.cpp
@@ -152,3 +152,8 @@ void ComponentImage::SetColor(float4 color)
 {
 	this->color = color;
 }
+
+void ComponentImage::SetNativeSize() const
+{
+	owner->transform_2d.SetSize(float2(texture_to_render->width, texture_to_render->height));
+}

--- a/Engine/Component/ComponentImage.h
+++ b/Engine/Component/ComponentImage.h
@@ -32,10 +32,13 @@ private:
 public:
 	uint32_t texture_uuid = 0;
 	std::shared_ptr<Texture> texture_to_render;
+	bool preserve_aspect_ratio = false;
 
 	float4 color = float4::one;
 
 private:
 	GLuint program, vao, vbo;
+
+	float texture_aspect_ratio = 0.f;
 };
 #endif //_COMPONENTIMAGE_H_

--- a/Engine/Component/ComponentImage.h
+++ b/Engine/Component/ComponentImage.h
@@ -26,6 +26,8 @@ public:
 
 	void Render(float4x4* projection);
 
+	void SetNativeSize() const;
+
 private:
 	virtual void InitData();
 

--- a/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
+++ b/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
@@ -469,7 +469,8 @@ void PanelComponent::ShowComponentCanvasRendererWindow(ComponentCanvasRenderer* 
 	}
 }
 
-void PanelComponent::ShowComponentImageWindow(ComponentImage* component_image) {
+void PanelComponent::ShowComponentImageWindow(ComponentImage* component_image)
+{
 	if (ImGui::CollapsingHeader(ICON_FA_IMAGE " Image", ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		if (!ShowCommonComponentWindow(component_image))
@@ -503,7 +504,9 @@ void PanelComponent::ShowComponentImageWindow(ComponentImage* component_image) {
 			component_image->SetTextureToRender(selected_resource);
 		}
 
-		ImGui::ColorPicker3("Color", component_image->color.ptr());
+		ImGui::ColorPicker3("Color", component_image->color.ptr(), ImGuiColorEditFlags_AlphaBar);
+
+		ImGui::Checkbox("Preserve Aspect Ratio", &component_image->preserve_aspect_ratio);
 	}
 }
 

--- a/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
+++ b/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
@@ -507,6 +507,11 @@ void PanelComponent::ShowComponentImageWindow(ComponentImage* component_image)
 		ImGui::ColorEdit3("Color", component_image->color.ptr());
 
 		ImGui::Checkbox("Preserve Aspect Ratio", &component_image->preserve_aspect_ratio);
+
+		if (ImGui::Button("Set Native Size"))
+		{
+			component_image->SetNativeSize();
+		}
 	}
 }
 

--- a/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
+++ b/Engine/EditorUI/Panel/InspectorSubpanel/PanelComponent.cpp
@@ -504,7 +504,7 @@ void PanelComponent::ShowComponentImageWindow(ComponentImage* component_image)
 			component_image->SetTextureToRender(selected_resource);
 		}
 
-		ImGui::ColorPicker3("Color", component_image->color.ptr(), ImGuiColorEditFlags_AlphaBar);
+		ImGui::ColorEdit3("Color", component_image->color.ptr());
 
 		ImGui::Checkbox("Preserve Aspect Ratio", &component_image->preserve_aspect_ratio);
 	}

--- a/Engine/Module/ModuleDebugDraw.cpp
+++ b/Engine/Module/ModuleDebugDraw.cpp
@@ -718,6 +718,7 @@ void ModuleDebugDraw::RenderSelectedGameObjectHelpers() const
 
 		RenderCameraFrustum();
 		RenderLightGizmo();
+		RenderRectTransform(App->editor->selected_game_object);
 		//RenderBones();
 	}
 }


### PR DESCRIPTION
What's new:
- `ComponentImage` has an option to preserve texture aspect ratio.
- `ComponentImage` has an option to set transform size to native texture size.
- Minor bug fix