### PR TITLE
Fix Disable Physics Collision Bug

### DIFF
--- a/Engine/Component/ComponentCollider.cpp
+++ b/Engine/Component/ComponentCollider.cpp
@@ -284,7 +284,7 @@ CollisionInformation ComponentCollider::DetectCollisionWith(ComponentCollider* c
 	
 	CollisionInformation collision_info;
 
-	if (detect_collision && collider->detect_collision)
+	if (detect_collision && collider->detect_collision && (active_physics || collider->active_physics))
 	{	
 		int numManifolds = App->physics->world->getDispatcher()->getNumManifolds();
 		for (int i = 0; i < numManifolds; i++)


### PR DESCRIPTION
Tinniest of them all yet

Now collision can get detected no matter if the physics are enabled or not

Note: The description is larger than the commit