### PR TITLE
common quad on billboards and particles

### DIFF
--- a/Engine/Component/ComponentBillboard.h
+++ b/Engine/Component/ComponentBillboard.h
@@ -12,7 +12,7 @@
 
 class GameObject;
 class Texture;
-
+class Quad;
 class ComponentBillboard : public Component
 {
 public:
@@ -31,9 +31,7 @@ public:
 
 	ComponentBillboard();
 	ComponentBillboard(GameObject* owner);
-	~ComponentBillboard();
-
-	void CleanUp();
+	~ComponentBillboard() = default;
 
 	//Copy and move
 	ComponentBillboard(const ComponentBillboard& component_to_copy) = default;
@@ -50,7 +48,6 @@ public:
 	void CopyTo(Component* component_to_copy) const override;
 
 	void InitData();
-	void InitQuad();
 	void Update() override;
 
 	void Render(const float3& global_position);
@@ -91,7 +88,7 @@ public:
 	bool playing_once = false;
 private:
 	GLuint shader_program;
-	GLuint vbo, vao, ebo;
+	Quad* quad = nullptr;
 
     uint32_t texture_uuid = 0;
 	std::shared_ptr<Texture> billboard_texture = nullptr;

--- a/Engine/Component/ComponentImage.cpp
+++ b/Engine/Component/ComponentImage.cpp
@@ -68,7 +68,7 @@ void ComponentImage::Render(float4x4* projection)
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture_to_render->opengl_texture);
 
-		quad->Render();
+		quad->RenderArray();
 		glBindTexture(GL_TEXTURE_2D, 0);
 		glUseProgram(0);
 	}

--- a/Engine/Component/ComponentParticleSystem.cpp
+++ b/Engine/Component/ComponentParticleSystem.cpp
@@ -180,10 +180,7 @@ void ComponentParticleSystem::Render()
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, ssbo);
 
 		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-		glBindVertexArray(billboard->vao);
-		glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, particles.size());
-		glBindVertexArray(0);
-
+		billboard->quad->RenderInstanced(particles.size());
 
 		glUseProgram(0);
 	}

--- a/Engine/Component/ComponentParticleSystem.h
+++ b/Engine/Component/ComponentParticleSystem.h
@@ -13,7 +13,6 @@
 
 class GameObject;
 class ComponentBillboard;
-
 const int MAX_PARTICLES = 500;
 
 class ComponentParticleSystem : public Component

--- a/Engine/Component/ComponentVideoPlayer.cpp
+++ b/Engine/Component/ComponentVideoPlayer.cpp
@@ -92,7 +92,7 @@ void ComponentVideoPlayer::RenderTexture(math::float4x4 * projection, GLuint tex
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texture);
 
-	quad->Render();
+	quad->RenderArray();
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glUseProgram(0);
 }

--- a/Engine/Helper/Quad.cpp
+++ b/Engine/Helper/Quad.cpp
@@ -1,8 +1,45 @@
 #include "Quad.h"
 
-Quad::Quad()
+void Quad::InitQuadBillboard()
 {
-	GLfloat vertices[] = {
+	float vertices[20] =
+	{
+		0.5f,  0.5f, 0.0f,		1.0f, 1.0f,
+		0.5f, -0.5f, 0.0f,		1.0f, 0.0f,
+		-0.5f, -0.5f, 0.0f,		0.0f, 0.0f,
+		-0.5f,  0.5f, 0.0f,		0.0f, 1.0f
+	};
+	unsigned int indices[6] =
+	{
+		0, 1, 3,
+		1, 2, 3
+	};
+
+	glGenVertexArrays(1, &vao);
+	glGenBuffers(1, &vbo);
+	glGenBuffers(1, &ebo);
+
+	glBindVertexArray(vao);
+
+	glBindBuffer(GL_ARRAY_BUFFER, vbo);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(0);
+
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+	glEnableVertexAttribArray(1);
+
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindVertexArray(0);
+}
+
+void Quad::InitQuadUI()
+{
+		GLfloat vertices[] = {
 		// Pos      // Tex
 		-0.5f, 0.5f, 0.0f, 1.0f,
 		0.5f, -0.5f, 1.0f, 0.0f,
@@ -29,12 +66,27 @@ Quad::Quad()
 Quad::~Quad()
 {
 	glDeleteBuffers(1, &vbo);
+	glDeleteBuffers(1, &ebo);
 	glDeleteVertexArrays(1, &vao);
 }
 
-void Quad::Render() const
+void Quad::RenderArray() const
 {
 	glBindVertexArray(vao);
 	glDrawArrays(GL_TRIANGLES, 0, 6);
+	glBindVertexArray(0);
+}
+
+void Quad::RenderElement() const
+{
+	glBindVertexArray(vao);
+	glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+	glBindVertexArray(0);
+}
+
+void Quad::RenderInstanced(size_t size) const
+{
+	glBindVertexArray(vao);
+	glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, size);
 	glBindVertexArray(0);
 }

--- a/Engine/Helper/Quad.h
+++ b/Engine/Helper/Quad.h
@@ -5,11 +5,15 @@
 class Quad
 {
 public:
-	Quad();
+	Quad() = default;
+	void InitQuadBillboard();
+	void InitQuadUI();
 	~Quad();
 
-	void Render() const;
+	void RenderArray() const;
+	void RenderElement() const;
+	void RenderInstanced(size_t size) const;
 private:
-	GLuint vao, vbo;
+	GLuint vao, vbo, ebo;
 };
 

--- a/Engine/Module/ModuleEffects.cpp
+++ b/Engine/Module/ModuleEffects.cpp
@@ -8,6 +8,15 @@
 #include "Main/GameObject.h"
 #include <Brofiler/Brofiler.h>
 
+// Called before render is available
+bool ModuleEffects::Init()
+{
+	APP_LOG_SECTION("************ Module Effects Init ************");
+	quad = std::make_unique<Quad>();
+	quad->InitQuadBillboard();
+	return true;
+}
+
 bool ModuleEffects::CleanUp()
 {
 	for (auto& particle : particle_systems)

--- a/Engine/Module/ModuleEffects.h
+++ b/Engine/Module/ModuleEffects.h
@@ -4,6 +4,8 @@
 #include "Module.h"
 
 #include <vector>
+#include <memory>
+#include "Helper/Quad.h"
 
 class ComponentBillboard;
 class ComponentParticleSystem;
@@ -17,6 +19,8 @@ class ModuleEffects : public Module
 
 public:
 
+	bool Init() override;
+
 	bool CleanUp() override;
 	void Render();
 
@@ -29,6 +33,7 @@ public:
 	ComponentTrail* CreateComponentTrail(GameObject* owner);
 	void RemoveComponentTrail(ComponentTrail* trail_to_remove);
 
+	std::unique_ptr<Quad> quad = nullptr;
 private:
 	bool render_particles = true;
 	std::vector<ComponentBillboard*> billboards;

--- a/Engine/Module/ModuleUI.cpp
+++ b/Engine/Module/ModuleUI.cpp
@@ -23,6 +23,7 @@ bool ModuleUI::Init()
 {
 	APP_LOG_SECTION("************ Module UI Init ************");
 	quad = std::make_unique<Quad>();
+	quad->InitQuadUI();
 	return true;
 }
 


### PR DESCRIPTION
Use a common quad for particles and billboard instead of generetic a new one everytime to save memory and loading time